### PR TITLE
Fix applying systemd for Ubuntu; Disable default redis-server service

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -39,6 +39,7 @@ class redis::install (
 
         service { 'redis-server':
           ensure    => stopped,
+          enable    => false,
           subscribe => Package['redis-server']
         }
       }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -199,8 +199,10 @@ define redis::server (
       if $::operatingsystemmajrelease >= 7 { $has_systemd = true }
     }
     'Debian': {
-      $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
-      if $::operatingsystemmajrelease >= 8 { $has_systemd = true }
+      if ($::operatingsystem == 'Debian' and versioncmp($::operatingsystemmajrelease, '8') >= 0) or ($::operatingsystem == 'Ubuntu' and versioncmp($::operatingsystemmajrelease, '15.04') >= 0) {
+        $service_file = "/etc/systemd/system/redis-server_${redis_name}.service"
+        $has_systemd = true
+      }
     }
     default:  {
       $has_systemd = false


### PR DESCRIPTION
1. Systemd is only fully supported in Ubuntu 15.04 and later releases.
2. Disables the default redis-server service installed by the Debian/Ubuntu package, to ensure it doesn't restart on reboot, causing port conflicts and preventing the managed service from starting.